### PR TITLE
Fix TBLIS integration.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,14 @@ target_sources(
     src/tapp/product.c
   )
 
+set_property(
+   TARGET tapp
+   PROPERTY
+     CXX_STANDARD 20
+     CXX_STANDARD_REQUIRED YES
+     CXX_EXTENSIONS NO
+)
+
 target_include_directories(
   tapp
   PUBLIC
@@ -43,45 +51,19 @@ if(ENABLE_TBLIS)
 
   set(TBLIS_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/tblis)
 
-  include(ExternalProject)
+  include(FetchContent)
 
-  ExternalProject_Add(
+  FetchContent_Declare(
     tblis
     GIT_REPOSITORY https://github.com/devinamatthews/tblis.git
-    GIT_TAG 4de1919
+    GIT_TAG 9b95712
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/_deps/tblis
-    CONFIGURE_COMMAND <SOURCE_DIR>/configure
-                      --prefix=${TBLIS_INSTALL_DIR}
-    BUILD_COMMAND make V=1
-    INSTALL_COMMAND make install
     UPDATE_DISCONNECTED TRUE
-    LOG_CONFIGURE ON
-    LOG_BUILD ON
-    LOG_INSTALL ON
-    CMAKE_ARGS
-            -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
   )
 
-  add_library(tblis-interface INTERFACE)
-  add_dependencies(tblis-interface tblis)
-  target_include_directories(tblis-interface INTERFACE
-      "${TBLIS_INSTALL_DIR}/include"
-      "${TBLIS_INSTALL_DIR}/include/tblis"
-  )
-  set(TBLIS_LIBRARY_PATH "")
-  if(WIN32)
-      set(TBLIS_LIBRARY_PATH "${TBLIS_INSTALL_DIR}/lib/tblis.lib")
-  else()
-      set(TBLIS_LIBRARY_PATH "${TBLIS_INSTALL_DIR}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}tblis${CMAKE_SHARED_LIBRARY_SUFFIX}")
-  endif()
-  
-  target_link_libraries(tblis-interface INTERFACE
-      "${TBLIS_LIBRARY_PATH}"
-  )
+  FetchContent_MakeAvailable(tblis)
 
-  # Ensure `tblis` is built before the demo executable.
   target_compile_definitions(tapp PRIVATE ENABLE_TBLIS=1)
-  add_dependencies(tapp tblis)
 
   target_sources(
   tapp
@@ -107,7 +89,7 @@ if(ENABLE_TBLIS)
   target_link_libraries(
     tapp
     PUBLIC
-      tblis-interface
+      tblis-static
   )
 
   # ----------------------------------------------------------------------------
@@ -128,6 +110,13 @@ if(ENABLE_TBLIS)
       tapp
     )
 
+  set_property(
+    TARGET test++
+    PROPERTY
+      CXX_STANDARD 20
+      CXX_STANDARD_REQUIRED YES
+      CXX_EXTENSIONS NO
+  )
 
   add_test(
     NAME test++
@@ -149,6 +138,7 @@ target_sources(
    PRIVATE
      tapp # Linking to tapp provides everything needed.
   )
+
 
 add_test(
   NAME demo

--- a/src/tapp/attributes.h
+++ b/src/tapp/attributes.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 
+#include "util.h"
 #include "error.h"
 
 typedef intptr_t TAPP_attr;
@@ -10,10 +11,10 @@ typedef int TAPP_key;
 
 //TODO: predefined attributes? error conditions?
 
-TAPP_error TAPP_attr_set(TAPP_attr attr, TAPP_key key, void* value);
+TAPP_EXPORT TAPP_error TAPP_attr_set(TAPP_attr attr, TAPP_key key, void* value);
 
-TAPP_error TAPP_attr_get(TAPP_attr attr, TAPP_key key, void** value);
+TAPP_EXPORT TAPP_error TAPP_attr_get(TAPP_attr attr, TAPP_key key, void** value);
 
-TAPP_error TAPP_attr_clear(TAPP_attr attr, TAPP_key key);
+TAPP_EXPORT TAPP_error TAPP_attr_clear(TAPP_attr attr, TAPP_key key);
 
 #endif /* TAPP_ATTRIBUTES_H_ */

--- a/src/tapp/datatype.h
+++ b/src/tapp/datatype.h
@@ -1,6 +1,8 @@
 #ifndef TAPP_DATATYPE_H_
 #define TAPP_DATATYPE_H_
 
+#include "util.h"
+
 /*
  * Storage data types:
  *

--- a/src/tapp/error.h
+++ b/src/tapp/error.h
@@ -4,10 +4,12 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+#include "util.h"
+
 typedef int TAPP_error;
 
 /* Return true if the error code indicates success and false otherwise. */
-bool TAPP_check_success(TAPP_error error);
+TAPP_EXPORT bool TAPP_check_success(TAPP_error error);
 
 /*
  * Fill a user-provided buffer with an implementation-defined string explaining the error code. No more than maxlen-1
@@ -19,8 +21,8 @@ bool TAPP_check_success(TAPP_error error);
  *
  * TODO: should the null character be included in the return value?
  */
-size_t TAPP_explain_error(TAPP_error error,
-                          size_t maxlen,
-                          char* message);
+TAPP_EXPORT size_t TAPP_explain_error(TAPP_error error,
+                                      size_t maxlen,
+                                      char* message);
 
 #endif /* TAPP_ERROR_H_ */

--- a/src/tapp/executor.h
+++ b/src/tapp/executor.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 
+#include "util.h"
 #include "error.h"
 
 typedef intptr_t TAPP_executor;
@@ -12,6 +13,6 @@ typedef intptr_t TAPP_executor;
  *       devices probably can't be enumerated until you have a handle....
  */
 
-TAPP_error TAPP_destroy_executor(TAPP_executor exec);
+TAPP_EXPORT TAPP_error TAPP_destroy_executor(TAPP_executor exec);
 
 #endif /* TAPP_HANDLE_H_ */

--- a/src/tapp/handle.h
+++ b/src/tapp/handle.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 
+#include "util.h"
 #include "error.h"
 
 typedef intptr_t TAPP_handle;
@@ -18,6 +19,6 @@ typedef intptr_t TAPP_handle;
 
  //TODO: optional APIs with feature test macros
 
-TAPP_error TAPP_destroy_handle(TAPP_handle handle);
+TAPP_EXPORT TAPP_error TAPP_destroy_handle(TAPP_handle handle);
 
 #endif /* TAPP_HANDLE_H_ */

--- a/src/tapp/product.h
+++ b/src/tapp/product.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 
+#include "util.h"
 #include "error.h"
 #include "handle.h"
 #include "executor.h"
@@ -29,48 +30,48 @@ enum
 
 typedef intptr_t TAPP_tensor_product;
 
-TAPP_error TAPP_create_tensor_product(TAPP_tensor_product* plan,
-                                      TAPP_handle handle,
-                                      TAPP_element_op op_A,
-                                      TAPP_tensor_info A,
-                                      const int64_t* idx_A,
-                                      TAPP_element_op op_B,
-                                      TAPP_tensor_info B,
-                                      const int64_t* idx_B,
-                                      TAPP_element_op op_C,
-                                      TAPP_tensor_info C,
-                                      const int64_t* idx_C,
-                                      TAPP_element_op op_D,
-                                      TAPP_tensor_info D,
-                                      const int64_t* idx_D,
-                                      TAPP_prectype prec);
+TAPP_EXPORT TAPP_error TAPP_create_tensor_product(TAPP_tensor_product* plan,
+                                                  TAPP_handle handle,
+                                                  TAPP_element_op op_A,
+                                                  TAPP_tensor_info A,
+                                                  const int64_t* idx_A,
+                                                  TAPP_element_op op_B,
+                                                  TAPP_tensor_info B,
+                                                  const int64_t* idx_B,
+                                                  TAPP_element_op op_C,
+                                                  TAPP_tensor_info C,
+                                                  const int64_t* idx_C,
+                                                  TAPP_element_op op_D,
+                                                  TAPP_tensor_info D,
+                                                  const int64_t* idx_D,
+                                                  TAPP_prectype prec);
 
-TAPP_error TAPP_destory_tensor_product(TAPP_tensor_product plan);
-
+TAPP_EXPORT TAPP_error TAPP_destory_tensor_product(TAPP_tensor_product plan);
+ 
 //TODO: in-place operation: set C = NULL or TAPP_IN_PLACE?
-
-TAPP_error TAPP_execute_product(TAPP_tensor_product plan,
-                                TAPP_executor exec,
-                                TAPP_status* status,
-                                const void* alpha,
-                                const void* A,
-                                const void* B,
-                                const void* beta,
-                                const void* C,
-                                      void* D);
-
+ 
+TAPP_EXPORT TAPP_error TAPP_execute_product(TAPP_tensor_product plan,
+                                            TAPP_executor exec,
+                                            TAPP_status* status,
+                                            const void* alpha,
+                                            const void* A,
+                                            const void* B,
+                                            const void* beta,
+                                            const void* C,
+                                                  void* D);
+ 
 //TODO: is it always OK to pass NULL for exec?
 //TODO: can C be NULL/TAPP_IN_PLACE (in addition to array entries being NULL)?
 
-TAPP_error TAPP_execute_batched_product(TAPP_tensor_product plan,
-                                        TAPP_executor exec,
-                                        TAPP_status* status,
-                                        int num_batches,
-                                        const void* alpha,
-                                        const void** A,
-                                        const void** B,
-                                        const void* beta,
-                                        const void** C,
-                                              void** D);
+TAPP_EXPORT TAPP_error TAPP_execute_batched_product(TAPP_tensor_product plan,
+                                                    TAPP_executor exec,
+                                                    TAPP_status* status,
+                                                    int num_batches,
+                                                    const void* alpha,
+                                                    const void** A,
+                                                    const void** B,
+                                                    const void* beta,
+                                                    const void** C,
+                                                          void** D);
 
 #endif /* TAPP_PRODUCT_H_ */

--- a/src/tapp/status.h
+++ b/src/tapp/status.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 
+#include "util.h"
 #include "error.h"
 
 typedef intptr_t TAPP_status;
@@ -13,6 +14,6 @@ typedef intptr_t TAPP_status;
  * TODO: how to get data out? using attributes or separate standardized interface? implementation-defined?
  */
 
-TAPP_error TAPP_destroy_status(TAPP_status status);
+TAPP_EXPORT TAPP_error TAPP_destroy_status(TAPP_status status);
 
 #endif /* TAPP_STATUS_H_ */

--- a/src/tapp/tapp_ex_imp.h
+++ b/src/tapp/tapp_ex_imp.h
@@ -32,5 +32,5 @@ struct plan
     TAPP_prectype prec;
 };
 
-TAPP_error create_executor(TAPP_executor* exec);
-TAPP_error create_handle(TAPP_handle* handle);
+TAPP_EXPORT TAPP_error create_executor(TAPP_executor* exec);
+TAPP_EXPORT TAPP_error create_handle(TAPP_handle* handle);

--- a/src/tapp/tensor.h
+++ b/src/tapp/tensor.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 
+#include "util.h"
 #include "error.h"
 #include "datatype.h"
 
@@ -18,29 +19,29 @@ typedef intptr_t TAPP_tensor_info;
  *         using unsigned values? Same with nmode.
  */ 
 
-TAPP_error TAPP_create_tensor_info(TAPP_tensor_info* info,
-                                   TAPP_datatype type,
-                                   int nmode,
-                                   const int64_t* extents,
-                                   const int64_t* strides);
+TAPP_EXPORT TAPP_error TAPP_create_tensor_info(TAPP_tensor_info* info,
+                                               TAPP_datatype type,
+                                               int nmode,
+                                               const int64_t* extents,
+                                               const int64_t* strides);
 
-TAPP_error TAPP_destory_tensor_info(TAPP_tensor_info info);
+TAPP_EXPORT TAPP_error TAPP_destory_tensor_info(TAPP_tensor_info info);
 
-int TAPP_get_nmodes(TAPP_tensor_info info);
+TAPP_EXPORT int TAPP_get_nmodes(TAPP_tensor_info info);
 
-TAPP_error TAPP_set_nmodes(TAPP_tensor_info info,
-                           int nmodes);
+TAPP_EXPORT TAPP_error TAPP_set_nmodes(TAPP_tensor_info info,
+                                       int nmodes);
 
-void TAPP_get_extents(TAPP_tensor_info info,
-                      int64_t* extents);
+TAPP_EXPORT void TAPP_get_extents(TAPP_tensor_info info,
+                                  int64_t* extents);
 
-TAPP_error TAPP_set_extents(TAPP_tensor_info info,
-                            const int64_t* extents);
+TAPP_EXPORT TAPP_error TAPP_set_extents(TAPP_tensor_info info,
+                                        const int64_t* extents);
 
-void TAPP_get_strides(TAPP_tensor_info info,
-                      int64_t* strides);
+TAPP_EXPORT void TAPP_get_strides(TAPP_tensor_info info,
+                                  int64_t* strides);
 
-TAPP_error TAPP_set_strides(TAPP_tensor_info info,
-                            const int64_t* strides);
+TAPP_EXPORT TAPP_error TAPP_set_strides(TAPP_tensor_info info,
+                                        const int64_t* strides);
 
 #endif /* TAPP_TENSOR_H_ */

--- a/src/tapp/util.h
+++ b/src/tapp/util.h
@@ -1,0 +1,12 @@
+#ifndef TAPP_UTIL_H_
+#define TAPP_UTIL_H_
+
+// This does not currently support MSVC __dllexport
+#ifdef __cplusplus
+#define TAPP_EXPORT extern "C" __attribute__((visibility("default")))
+#else
+#define TAPP_EXPORT __attribute__((visibility("default")))
+#endif
+
+#endif
+

--- a/tblis_bindings/tblis_bind.h
+++ b/tblis_bindings/tblis_bind.h
@@ -6,35 +6,33 @@
 
 #ifndef TBLIS_BIND_H
 #define TBLIS_BIND_H
-#ifdef __cplusplus
-#include <iostream>
-#include <random>
-#include <tuple>
-#include <string>
-#include <complex>
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#include "tblis.h"
-#pragma GCC diagnostic pop
 
-extern "C" {
+#ifdef __cplusplus
+    #include <iostream>
+    #include <random>
+    #include <tuple>
+    #include <string>
+    #include <complex>
+    #pragma GCC diagnostic push
+    //#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #include "tblis.h"
+    #pragma GCC diagnostic pop
 #endif
-    #include "tapp.h"
+
+#include "tapp.h"
+
 #ifdef __cplusplus
     #include "tapp_ex_imp.h"
-}
-extern "C" {
 #endif
-  void bind_tblis_execute_product(int nmode_A, int64_t* extents_A, int64_t* strides_A, void* A, int op_A, int64_t* idx_A,
+
+TAPP_EXPORT void
+bind_tblis_execute_product(int nmode_A, int64_t* extents_A, int64_t* strides_A, void* A, int op_A, int64_t* idx_A,
                     int nmode_B, int64_t* extents_B, int64_t* strides_B, void* B, int op_B, int64_t* idx_B,
                     int nmode_C, int64_t* extents_C, int64_t* strides_C, void* C, int op_C, int64_t* idx_C,
                     int nmode_D, int64_t* extents_D, int64_t* strides_D, void* D, int op_D, int64_t* idx_D,
                     void* alpha, void* beta, int datatype_tapp);
 
-  int compare_tensors_(void* A, void* B, int64_t size, int datatype_tapp);
-#ifdef __cplusplus
-}
-#endif
+TAPP_EXPORT int compare_tensors_(void* A, void* B, int64_t size, int datatype_tapp);
 
 #endif
 


### PR DESCRIPTION
- Update TBLIS commit ref.
- Use FetchContent instead of ExternalPackage and use TBLIS cmake target.
- Add `TBLIS_EXPORT` macro to make the TAPP interface C++-safe, and also to support symbol visibility and (eventually) `__dllexport` on Windows.
- Use C++20 as this is required for the TBLIS C++ interface.
- Clean up various other bits.