### PR TITLE
fix compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,10 @@ target_include_directories(
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/src
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tapp
-  )
-
+)
+if (APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "^(Clang|AppleClang)$")
+  target_link_options(tapp PRIVATE "-undefined;dynamic_lookup")
+endif()
 
   enable_testing()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,9 @@ if (APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "^(Clang|AppleClang)$")
   target_link_options(tapp PRIVATE "-undefined;dynamic_lookup")
 endif()
 
-  enable_testing()
+enable_testing()
 
-  option(ENABLE_TBLIS "Build and link TBLIS and TBLIS bindings" OFF)
+option(ENABLE_TBLIS "Build and link TBLIS and TBLIS bindings" OFF)
 
 if(ENABLE_TBLIS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,9 @@ target_sources(
 set_property(
    TARGET tapp
    PROPERTY
-     CXX_STANDARD 20
-     CXX_STANDARD_REQUIRED YES
-     CXX_EXTENSIONS NO
+     C_STANDARD 99
+     C_STANDARD_REQUIRED YES
+     C_EXTENSIONS NO
 )
 
 target_include_directories(

--- a/Makefile
+++ b/Makefile
@@ -110,12 +110,19 @@ else #linux
 endif
 
 
+# Conditional linking flags for macOS
+ifeq ($(UNAME_S),Darwin)
+  UNDEFINED_FLAG = -undefined dynamic_lookup
+else
+  UNDEFINED_FLAG =
+endif
+
 ifeq ($(ENABLE_TBLIS),true)
 lib/libtapp$(LIBEXT): $(OBJ)/tapp.o $(OBJ)/tblis_bind.o
-	$(CXX) -shared -fPIC $(OBJ)/tapp.o $(OBJ)/tblis_bind.o -o lib/libtapp$(LIBEXT) $(SONAME) -I$(INC) -I$(INC)/tapp -I$(TBL) $(TBLIS_PARAM)
+	$(CXX) -shared -fPIC $(OBJ)/tapp.o $(OBJ)/tblis_bind.o -o lib/libtapp$(LIBEXT) $(SONAME) -I$(INC) -I$(INC)/tapp -I$(TBL) $(TBLIS_PARAM) $(UNDEFINED_FLAG)
 else
 lib/libtapp$(LIBEXT): $(OBJ)/tapp.o $(OBJ)/tblis_bind.o
-	$(CXX) -shared -fPIC $(OBJ)/tapp.o -o lib/libtapp$(LIBEXT) $(SONAME) -I$(INC) -I$(INC)/tapp -I$(TBL) $(TBLIS_PARAM)
+	$(CXX) -shared -fPIC $(OBJ)/tapp.o -o lib/libtapp$(LIBEXT) $(SONAME) -I$(INC) -I$(INC)/tapp -I$(TBL) $(TBLIS_PARAM) $(UNDEFINED_FLAG)
 endif
 
 ifeq ($(ENABLE_TBLIS),true)

--- a/src/tapp/product.c
+++ b/src/tapp/product.c
@@ -50,7 +50,7 @@ void zero_sum(void* sum, TAPP_prectype prec, TAPP_datatype type, bool is_complex
 void zero_accum(void* accum, TAPP_prectype prec, TAPP_datatype type, bool is_complex);
 bool is_equal(const void* val, TAPP_datatype type, const void* comp_val, TAPP_datatype comp_type);
 void compress_repeated_indices(int* nmode, int64_t** idx, int64_t** extents, int64_t** strides);
-void print_tensor_(int nmode, int64_t* extents, int64_t* strides, void* data, TAPP_datatype type);
+void print_tensor_(int nmode, const int64_t* extents, const int64_t* strides, const void* data, TAPP_datatype type);
 
 
 TAPP_error TAPP_create_tensor_product(TAPP_tensor_product* plan,
@@ -128,7 +128,7 @@ TAPP_error TAPP_execute_product(TAPP_tensor_product plan,
                                 void* D)
 {
     struct plan* plan_ptr = (struct plan*)plan;
-    TAPP_handle handle = plan_ptr->handle;
+    //TAPP_handle handle = plan_ptr->handle;
 
     TAPP_element_op op_A = plan_ptr->op_A;
     TAPP_tensor_info A_info = (TAPP_tensor_info)(plan_ptr->A);
@@ -454,7 +454,7 @@ TAPP_error TAPP_execute_product(TAPP_tensor_product plan,
     return 0;
 }
 
-void print_tensor_(int nmode, int64_t* extents, int64_t* strides, void* data_, TAPP_datatype type) {
+void print_tensor_(int nmode, const int64_t* extents, const int64_t* strides, const void* data_, TAPP_datatype type) {
     
     int64_t* coords;
     if(nmode > 0) coords = malloc(nmode * sizeof(int64_t));
@@ -477,21 +477,29 @@ void print_tensor_(int nmode, int64_t* extents, int64_t* strides, void* data_, T
         }
         switch (type) { // tapp_datatype
           case TAPP_F32:
+          {
             float* datas = (float*) data_;
             printf("%.3f", datas[index]);
             break;
+          }
           case TAPP_F64:
+          {
             double* datad = (double*) data_;
             printf("%.3f", datad[index]);
             break;
+          }
           case TAPP_C32:
+          {
             float complex* datac = (float complex*) data_;
             printf("%.3f+%.3fi", crealf(datac[index]), cimagf(datac[index]));
             break;
+          }
           case TAPP_C64:
+          {
             double complex* dataz = (double complex*) data_;
             printf("%.3f+%.3fi", creal(dataz[index]), cimag(dataz[index]));
             break;
+          }
         } 
 
         if (nmode <= 0) continue;
@@ -833,7 +841,7 @@ int check_self_aliasing(int nmode, const int64_t* extents, const int64_t* stride
     int64_t* sorted_extents = malloc(nmode * sizeof(int64_t));
     for (size_t i = 0; i < nmode; i++)
     {
-        sorted_strides[i] = abs(strides[i]);
+        sorted_strides[i] = labs(strides[i]);
         sorted_extents[i] = extents[i];
     }
     merge_sort_strides(sorted_strides, sorted_extents, 0, nmode - 1);

--- a/test/driver.c
+++ b/test/driver.c
@@ -165,7 +165,7 @@ int main(int argc, char const *argv[])
     int message_len = TAPP_explain_error(error, 0, NULL); // Get size of error message
     char *message_buff = malloc((message_len + 1) * sizeof(char)); // Allocate buffer for message, including null terminator
     TAPP_explain_error(error, message_len + 1, message_buff); // Fetch error message
-    printf(message_buff); // Print message
+    printf("%s", message_buff); // Print message
     free(message_buff); // Free buffer
     printf("\n");
 

--- a/test/helpers.c
+++ b/test/helpers.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-void print_tensor_s(int nmode, int64_t *extents, int64_t *strides, float *data)
+void print_tensor_s(int nmode, const int64_t *extents, const int64_t *strides, const float *data)
 {
     int64_t *coords = malloc(nmode * sizeof(int64_t));
     int64_t size = 1;
@@ -52,7 +52,7 @@ void print_tensor_s(int nmode, int64_t *extents, int64_t *strides, float *data)
     free(coords);
 }
 
-void print_tensor_c(int nmode, int64_t *extents, int64_t *strides, float complex *data)
+void print_tensor_c(int nmode, const int64_t *extents, const int64_t *strides, const float complex *data)
 {
     int64_t *coords = malloc(nmode * sizeof(int64_t));
     int64_t size = 1;

--- a/test/helpers.h
+++ b/test/helpers.h
@@ -7,5 +7,5 @@
 #include <complex.h>
 #include <stdint.h>
 
-void print_tensor_s(int nmode, int64_t *extents, int64_t *strides, float *data);
-void print_tensor_c(int nmode, int64_t *extents, int64_t *strides, float complex *data);
+void print_tensor_s(int nmode, const int64_t *extents, const int64_t *strides, const float *data);
+void print_tensor_c(int nmode, const int64_t *extents, const int64_t *strides, const float complex *data);


### PR DESCRIPTION
1. use const in print_tensor_ since all the pointer args are read-only
2. add {} in case-switch to avoid needing C23
3. comment out an unused variable