### PR TITLE
include cutensor.h instead of cutensor/types.h to inject cuda_runtime.h

### DIFF
--- a/cutensor_bindings/include/datatype.h
+++ b/cutensor_bindings/include/datatype.h
@@ -3,7 +3,7 @@
 
 #include <tapp/datatype.h>
 
-#include <cutensor/types.h>
+#include <cutensor.h>
 
 #include <complex>
 

--- a/cutensor_bindings/include/tensor.h
+++ b/cutensor_bindings/include/tensor.h
@@ -3,7 +3,7 @@
 
 #include <tapp/tensor.h>
 
-#include <cutensor/types.h>
+#include <cutensor.h>
 
 #include <cstring>
 


### PR DESCRIPTION
Headers `cutensor_bindings/include/datatype.h` and `tensor.h` include `<cutensor/types.h>` header only.

However, this does not pull in `<cuda_runtime.h>`, hence lacking `<library_types.h>` leading to a build error

Example build attempt using conda env
```
[ 22%] Building CXX object cutensor_bindings/CMakeFiles/tapp-cutensor.dir/src/datatype.cpp.o
cd /home/XXX/Projects/scratch/tapp-torch/third_party/tapp/build/cutensor_bindings && /home/XXX/Software/miniconda3/envs/default/bin/x86_64-conda-linux-gnu-c++ -Dtapp_cutensor_EXPORTS 
-I/home/XXX/Projects/scratch/tapp-torch/third_party/tapp/cutensor_bindings/include 
-I/home/XXX/Projects/scratch/tapp-torch/third_party/tapp/api/include 
-isystem /home/XXX/Software/miniconda3/envs/default/targets/x86_64-linux/include/cccl 
-fvisibility-inlines-hidden -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe 
-isystem /home/XXX/Software/miniconda3/envs/default/include  
-I/home/XXX/Software/miniconda3/envs/default/targets/x86_64-linux/include 
-std=gnu++20 -fPIC -MD -MT cutensor_bindings/CMakeFiles/tapp-cutensor.dir/src/datatype.cpp.o -MF CMakeFiles/tapp-cutensor.dir/src/datatype.cpp.o.d -o CMakeFiles/tapp-cutensor.dir/src/datatype.cpp.o -c /home/XXX/Projects/scratch/tapp-torch/third_party/tapp/cutensor_bindings/src/datatype.cpp
In file included from /home/XXX/Projects/scratch/tapp-torch/third_party/tapp/cutensor_bindings/src/../include/datatype.h:6,
                 from /home/XXX/Projects/scratch/tapp-torch/third_party/tapp/cutensor_bindings/src/datatype.cpp:1:
/home/XXX/Software/miniconda3/envs/default/include/cutensor/types.h:26:9: error: 'cudaDataType_t' does not name a type
   26 | typedef cudaDataType_t cutensorDataType_t;
```

or in nvcr.io/nvidia/cuda-dl-base:25.06-cuda12.9-devel-ubuntu24.04 container with cuTensor
```
[ 22%] Building CXX object cutensor_bindings/CMakeFiles/tapp-cutensor.dir/src/datatype.cpp.o
cd /users/YYY/yastn/third_party/TAPP-torch/third_party/tapp/build/cutensor_bindings && /usr/bin/c++ -Dtapp_cutensor_EXPORTS 
-I/users/YYY/yastn/third_party/TAPP-torch/third_party/tapp/cutensor_bindings/include 
-I/users/YYY/yastn/third_party/TAPP-torch/third_party/tapp/api/include 
-isystem /usr/local/cuda/include 
-isystem /usr/local/cuda/targets/sbsa-linux/include 
-std=gnu++20 -fPIC -MD -MT cutensor_bindings/CMakeFiles/tapp-cutensor.dir/src/datatype.cpp.o -MF CMakeFiles/tapp-cutensor.dir/src/datatype.cpp.o.d -o CMakeFiles/tapp-cutensor.dir/src/datatype.cpp.o -c /users/YYY/yastn/third_party/TAPP-torch/third_party/tapp/cutensor_bindings/src/datatype.cpp
In file included from /users/YYY/yastn/third_party/TAPP-torch/third_party/tapp/cutensor_bindings/src/../include/datatype.h:6,
                 from /users/YYY/yastn/third_party/TAPP-torch/third_party/tapp/cutensor_bindings/src/datatype.cpp:1:
/usr/local/cuda/include/cutensor/types.h:26:9: error: ‘cudaDataType_t’ does not name a type
   26 | typedef cudaDataType_t cutensorDataType_t;
```

Previously, the sources had `*.cu` extension, thus being compiled by `nvcc` which automatically injected necessary headers